### PR TITLE
Add gamma / srgb fix

### DIFF
--- a/resize_test.go
+++ b/resize_test.go
@@ -1,6 +1,7 @@
 package resize
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 	"runtime"
@@ -50,6 +51,75 @@ func Test_CorrectResize(t *testing.T) {
 	m := Resize(60, 0, zeroImg, NearestNeighbor)
 	if m.Bounds() != image.Rect(0, 0, 60, 60) {
 		t.Fail()
+	}
+}
+
+func Test_ResizeGamma(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 256, 256))
+
+	// Alternating white and black pixels
+	for y := 0; y < 256; y += 1 {
+		for x := 0; x < 256; x += 1 {
+			if (x+y)&1 == 0 {
+				img.Set(x, y, color.White)
+			} else {
+				img.Set(x, y, color.Black)
+			}
+		}
+	}
+
+	// The expected result is 50% gray in energy-linear space.
+	// In 8-bit sRGB, that is 186.
+	expected := color.RGBA{188, 188, 188, 255}
+
+	m := Resize(64, 0, img, NearestNeighbor)
+	for y := 0; y < 64; y += 1 {
+		for x := 0; x < 64; x += 1 {
+			// Compare with 8-bit precision (as used by expected).
+			r1, _, _, _ := expected.RGBA()
+			r2, _, _, _ := m.At(x, y).RGBA()
+			if r1>>8 != r2>>8 {
+				fmt.Printf("expected: %d\n", r1)
+				fmt.Printf("actual:  %d\n", r2)
+				t.Fail()
+				return
+			}
+		}
+	}
+}
+
+func Test_ResizeAlpha(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 256, 256))
+
+	// Alternating black and 100% transparent pixels
+	for y := 0; y < 256; y += 1 {
+		for x := 0; x < 256; x += 1 {
+			if (x+y)&1 == 0 {
+				img.Set(x, y, color.Black)
+			} else {
+				img.Set(x, y, color.Transparent)
+			}
+		}
+	}
+
+	// The expected result is 50% alpha with 0 RGB.
+	expected := color.RGBA{0, 0, 0, 127}
+
+	m := Resize(64, 0, img, NearestNeighbor)
+	for y := 0; y < 64; y += 1 {
+		for x := 0; x < 64; x += 1 {
+			// Compare with 8-bit precision (as used by expected).
+			r1, _, _, a1 := expected.RGBA()
+			r2, _, _, a2 := m.At(x, y).RGBA()
+			if r1>>8 != r2>>8 || a1>>8 != a2>>8 {
+				fmt.Println("expected", r1, a1)
+				fmt.Println("actual", r2, a2)
+				r,g,b,a := color.Transparent.RGBA()
+				fmt.Println(r,g,b,a)
+				t.Fail()
+				return
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Hello Jan,

Thank you for your high quality image resizing library.  I am working on a software rendering project in go today and needed a resize library to prepare mipmaps for texturing.  Yours was easy to integrate and gives nice results.

One thing I noticed is that it does not seem to handle gamma.  I only noticed because this is an issue I have had to wrestle with in my renderer.  It seems the go image libraries do not address the question of color spaces or gamma correction, instead they simply assume values are in sRGB.  This is a decent assumption since it is such a broadly used standard, however it means the color values are not energy-linear, and so we cannot do things like linear-interpolate colors or apply filters without having to correct for this.  

I linked to a web page that describes the issue pretty well, and came up with a fix.  Since you had already taken the step of providing high-quality reconstruction filters (Lanczos) I thought you might be interested.  I ran the benchmark and it added about 15% more runtime.  Feel free to use it, change it, or ignore it. 

Dankeschön,
Brett.

...

Go's image and color libraries do not address the issues of color
profiles or gamma; instead, they appear to use the common working
assumption that colors are expresed in sRGB.  This can be an issue
when doing things like resampling an image, since applying linear
operators require values to be an in linear space, not an exponential
space like sRGB.  This page has some examples:

```
http://www.4p8.com/eric.brasseur/gamma.html
```

This change adds an internal conversion between sRGB and linear
before resampling the signal.  It also makes sure to separate alpha,
which is pre-multiplied in color.Color.  With this change, the Dalai
Lama example from the page above scales as expected.
