### PR TITLE
Dst pixel coordinate fix

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -87,7 +87,7 @@ func createWeights8(dy, filterLength int, blur, scale float64, kernel func(float
 	coeffs := make([]int16, dy*filterLength)
 	start := make([]int, dy)
 	for y := 0; y < dy; y++ {
-		interpX := scale * (float64(y) + 0.5)
+		interpX := scale*(float64(y)+0.5) - 0.5
 		start[y] = int(interpX) - filterLength/2 + 1
 		interpX -= float64(start[y])
 		for i := 0; i < filterLength; i++ {
@@ -107,7 +107,7 @@ func createWeights16(dy, filterLength int, blur, scale float64, kernel func(floa
 	coeffs := make([]int32, dy*filterLength)
 	start := make([]int, dy)
 	for y := 0; y < dy; y++ {
-		interpX := scale * (float64(y) + 0.5)
+		interpX := scale*(float64(y)+0.5) - 0.5
 		start[y] = int(interpX) - filterLength/2 + 1
 		interpX -= float64(start[y])
 		for i := 0; i < filterLength; i++ {
@@ -126,7 +126,7 @@ func createWeightsNearest(dy, filterLength int, blur, scale float64) ([]bool, []
 	coeffs := make([]bool, dy*filterLength)
 	start := make([]int, dy)
 	for y := 0; y < dy; y++ {
-		interpX := scale * (float64(y) + 0.5)
+		interpX := scale*(float64(y)+0.5) - 0.5
 		start[y] = int(interpX) - filterLength/2 + 1
 		interpX -= float64(start[y])
 		for i := 0; i < filterLength; i++ {


### PR DESCRIPTION
Hi,
I believe pixel position calculation isn't quite correct. 
Here's a demo:
```go
package main

import (
	"image"
	"image/png"
	"os"

	"github.com/nfnt/resize"
)

func main() {
	checkers := image.NewGray(image.Rect(0, 0, 4, 4))
	checkers.Pix = []uint8{
		255, 0, 255, 0,
		0, 255, 0, 255,
		255, 0, 255, 0,
		0, 255, 0, 255,
	}
	dst := resize.Resize(100, 100, checkers, resize.NearestNeighbor)
	SaveImage(dst, "test.png")
}

func SaveImage(img image.Image, f string) {
	out, err := os.Create(f)
	if err != nil {
		panic(err)
	}
	defer out.Close()
	png.Encode(out, img)
}
```
Expected result:
![test2](https://cloud.githubusercontent.com/assets/2706839/6739879/ed3224de-ce8c-11e4-8f78-bbd3d7a02df0.png)

Actual result:
![test](https://cloud.githubusercontent.com/assets/2706839/6739886/058b42d6-ce8d-11e4-90fa-ff6795eaa94c.png)

The proposed change fixes the issue.