### PR TITLE
Fix 411 and 410 Subsampling ratios in ycc.go

### DIFF
--- a/ycc.go
+++ b/ycc.go
@@ -137,6 +137,34 @@ func (p *ycc) YCbCr() *image.YCbCr {
 				off += 3
 			}
 		}
+	case image.YCbCrSubsampleRatio411:
+		for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
+			yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
+			cy := (y - ycbcr.Rect.Min.Y) * ycbcr.CStride
+			for x := ycbcr.Rect.Min.X; x < ycbcr.Rect.Max.X; x++ {
+				xx := (x - ycbcr.Rect.Min.X)
+				yi := yy + xx
+				ci := cy + xx/4
+				ycbcr.Y[yi] = p.Pix[off+0]
+				ycbcr.Cb[ci] = p.Pix[off+1]
+				ycbcr.Cr[ci] = p.Pix[off+2]
+				off += 3
+			}
+		}
+	case image.YCbCrSubsampleRatio410:
+		for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
+			yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
+			cy := (y/2 - ycbcr.Rect.Min.Y/2) * ycbcr.CStride
+			for x := ycbcr.Rect.Min.X; x < ycbcr.Rect.Max.X; x++ {
+				xx := (x - ycbcr.Rect.Min.X)
+				yi := yy + xx
+				ci := cy + xx/4
+				ycbcr.Y[yi] = p.Pix[off+0]
+				ycbcr.Cb[ci] = p.Pix[off+1]
+				ycbcr.Cr[ci] = p.Pix[off+2]
+				off += 3
+			}
+		}
 	default:
 		// Default to 4:4:4 subsampling.
 		for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
@@ -201,6 +229,34 @@ func imageYCbCrToYCC(in *image.YCbCr) *ycc {
 				xx := (x - in.Rect.Min.X)
 				yi := yy + xx
 				ci := cy + xx
+				p.Pix[off+0] = in.Y[yi]
+				p.Pix[off+1] = in.Cb[ci]
+				p.Pix[off+2] = in.Cr[ci]
+				off += 3
+			}
+		}
+	case image.YCbCrSubsampleRatio411:
+		for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
+			yy := (y - in.Rect.Min.Y) * in.YStride
+			cy := (y - in.Rect.Min.Y) * in.CStride
+			for x := in.Rect.Min.X; x < in.Rect.Max.X; x++ {
+				xx := (x - in.Rect.Min.X)
+				yi := yy + xx
+				ci := cy + xx/4
+				p.Pix[off+0] = in.Y[yi]
+				p.Pix[off+1] = in.Cb[ci]
+				p.Pix[off+2] = in.Cr[ci]
+				off += 3
+			}
+		}
+	case image.YCbCrSubsampleRatio410:
+		for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
+			yy := (y - in.Rect.Min.Y) * in.YStride
+			cy := (y/2 - in.Rect.Min.Y/2) * in.CStride
+			for x := in.Rect.Min.X; x < in.Rect.Max.X; x++ {
+				xx := (x - in.Rect.Min.X)
+				yi := yy + xx
+				ci := cy + xx/4
 				p.Pix[off+0] = in.Y[yi]
 				p.Pix[off+1] = in.Cb[ci]
 				p.Pix[off+2] = in.Cr[ci]

--- a/ycc.go
+++ b/ycc.go
@@ -21,6 +21,12 @@ import (
 	"image/color"
 )
 
+// Allow compilation with Go versions before 1.5.
+const (
+	yCbCrSubsampleRatio411 = image.YCbCrSubsampleRatio(4)
+	yCbCrSubsampleRatio410 = image.YCbCrSubsampleRatio(5)
+)
+
 // ycc is an in memory YCbCr image.  The Y, Cb and Cr samples are held in a
 // single slice to increase resizing performance.
 type ycc struct {
@@ -137,7 +143,7 @@ func (p *ycc) YCbCr() *image.YCbCr {
 				off += 3
 			}
 		}
-	case image.YCbCrSubsampleRatio411:
+	case yCbCrSubsampleRatio411:
 		for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
 			yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
 			cy := (y - ycbcr.Rect.Min.Y) * ycbcr.CStride
@@ -151,7 +157,7 @@ func (p *ycc) YCbCr() *image.YCbCr {
 				off += 3
 			}
 		}
-	case image.YCbCrSubsampleRatio410:
+	case yCbCrSubsampleRatio410:
 		for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
 			yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
 			cy := (y/2 - ycbcr.Rect.Min.Y/2) * ycbcr.CStride
@@ -235,7 +241,7 @@ func imageYCbCrToYCC(in *image.YCbCr) *ycc {
 				off += 3
 			}
 		}
-	case image.YCbCrSubsampleRatio411:
+	case yCbCrSubsampleRatio411:
 		for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
 			yy := (y - in.Rect.Min.Y) * in.YStride
 			cy := (y - in.Rect.Min.Y) * in.CStride
@@ -249,7 +255,7 @@ func imageYCbCrToYCC(in *image.YCbCr) *ycc {
 				off += 3
 			}
 		}
-	case image.YCbCrSubsampleRatio410:
+	case yCbCrSubsampleRatio410:
 		for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
 			yy := (y - in.Rect.Min.Y) * in.YStride
 			cy := (y/2 - in.Rect.Min.Y/2) * in.CStride

--- a/ycc_test.go
+++ b/ycc_test.go
@@ -33,6 +33,8 @@ func TestImage(t *testing.T) {
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio422),
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio440),
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio444),
+		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio411),
+		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio410),
 	}
 	for _, m := range testImage {
 		if !image.Rect(0, 0, 10, 10).Eq(m.Bounds()) {
@@ -60,6 +62,8 @@ func TestConvertYCbCr(t *testing.T) {
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio422),
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio440),
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio444),
+		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio411),
+		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio410),
 	}
 
 	for _, img := range testImage {
@@ -149,6 +153,8 @@ func TestYCbCr(t *testing.T) {
 		image.YCbCrSubsampleRatio422,
 		image.YCbCrSubsampleRatio420,
 		image.YCbCrSubsampleRatio440,
+		image.YCbCrSubsampleRatio411,
+		image.YCbCrSubsampleRatio410,
 	}
 	deltas := []image.Point{
 		image.Pt(0, 0),

--- a/ycc_test.go
+++ b/ycc_test.go
@@ -33,8 +33,8 @@ func TestImage(t *testing.T) {
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio422),
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio440),
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio444),
-		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio411),
-		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio410),
+		newYCC(image.Rect(0, 0, 10, 10), yCbCrSubsampleRatio411),
+		newYCC(image.Rect(0, 0, 10, 10), yCbCrSubsampleRatio410),
 	}
 	for _, m := range testImage {
 		if !image.Rect(0, 0, 10, 10).Eq(m.Bounds()) {
@@ -62,8 +62,8 @@ func TestConvertYCbCr(t *testing.T) {
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio422),
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio440),
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio444),
-		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio411),
-		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio410),
+		image.NewYCbCr(image.Rect(0, 0, 50, 50), yCbCrSubsampleRatio411),
+		image.NewYCbCr(image.Rect(0, 0, 50, 50), yCbCrSubsampleRatio410),
 	}
 
 	for _, img := range testImage {
@@ -153,8 +153,8 @@ func TestYCbCr(t *testing.T) {
 		image.YCbCrSubsampleRatio422,
 		image.YCbCrSubsampleRatio420,
 		image.YCbCrSubsampleRatio440,
-		image.YCbCrSubsampleRatio411,
-		image.YCbCrSubsampleRatio410,
+		yCbCrSubsampleRatio411,
+		yCbCrSubsampleRatio410,
 	}
 	deltas := []image.Point{
 		image.Pt(0, 0),


### PR DESCRIPTION
Resolves #37

The subsampling ratios were added in Go 1.5.  Previously, trying to open an image with one of these ratios would fail before they could be resized.  Since adding them, it is now possible to attempt to resize them, resulting in a runtime panic.  

I see that the the travis tests are failing, due to the new ratios not being in the tested Go versions.  I see two viable options:  

1.  Hard code the sampling ratio numbers into the switch, and just put a comment saying what they stand for.
2.  Update Travis to use go 1.5  