### PR TITLE
support YCbCr subsample ratios 4:1:0 and 4:1:1

### DIFF
--- a/ycc.go
+++ b/ycc.go
@@ -137,33 +137,37 @@ func (p *ycc) YCbCr() *image.YCbCr {
 				off += 3
 			}
 		}
-	case image.YCbCrSubsampleRatio410:
-		for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
-			yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
-			cy := (y/2 - ycbcr.Rect.Min.Y/2) * ycbcr.CStride
-			for x := ycbcr.Rect.Min.X; x < ycbcr.Rect.Max.X; x++ {
-				xx := (x - ycbcr.Rect.Min.X)
-				yi := yy + xx
-				ci := cy + xx/4
-				ycbcr.Y[yi] = p.Pix[off+0]
-				ycbcr.Cb[ci] = p.Pix[off+1]
-				ycbcr.Cr[ci] = p.Pix[off+2]
-				off += 3
-			}
-		}
 	default:
-		// Default to 4:4:4 subsampling.
-		for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
-			yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
-			cy := (y - ycbcr.Rect.Min.Y) * ycbcr.CStride
-			for x := ycbcr.Rect.Min.X; x < ycbcr.Rect.Max.X; x++ {
-				xx := (x - ycbcr.Rect.Min.X)
-				yi := yy + xx
-				ci := cy + xx
-				ycbcr.Y[yi] = p.Pix[off+0]
-				ycbcr.Cb[ci] = p.Pix[off+1]
-				ycbcr.Cr[ci] = p.Pix[off+2]
-				off += 3
+		// String is used to avoid Go build errors on older
+		// versions of Go.
+		if ycbcr.SubsampleRatio.String() == "YCbCrSubsampleRatio410" {
+			for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
+				yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
+				cy := (y/2 - ycbcr.Rect.Min.Y/2) * ycbcr.CStride
+				for x := ycbcr.Rect.Min.X; x < ycbcr.Rect.Max.X; x++ {
+					xx := (x - ycbcr.Rect.Min.X)
+					yi := yy + xx
+					ci := cy + xx/4
+					ycbcr.Y[yi] = p.Pix[off+0]
+					ycbcr.Cb[ci] = p.Pix[off+1]
+					ycbcr.Cr[ci] = p.Pix[off+2]
+					off += 3
+				}
+			}
+		} else {
+			// Default to 4:4:4 subsampling.
+			for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
+				yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
+				cy := (y - ycbcr.Rect.Min.Y) * ycbcr.CStride
+				for x := ycbcr.Rect.Min.X; x < ycbcr.Rect.Max.X; x++ {
+					xx := (x - ycbcr.Rect.Min.X)
+					yi := yy + xx
+					ci := cy + xx
+					ycbcr.Y[yi] = p.Pix[off+0]
+					ycbcr.Cb[ci] = p.Pix[off+1]
+					ycbcr.Cr[ci] = p.Pix[off+2]
+					off += 3
+				}
 			}
 		}
 	}
@@ -221,33 +225,37 @@ func imageYCbCrToYCC(in *image.YCbCr) *ycc {
 				off += 3
 			}
 		}
-	case image.YCbCrSubsampleRatio410:
-		for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
-			yy := (y - in.Rect.Min.Y) * in.YStride
-			cy := (y/2 - in.Rect.Min.Y/2) * in.CStride
-			for x := in.Rect.Min.X; x < in.Rect.Max.X; x++ {
-				xx := (x - in.Rect.Min.X)
-				yi := yy + xx
-				ci := cy + xx/4
-				p.Pix[off+0] = in.Y[yi]
-				p.Pix[off+1] = in.Cb[ci]
-				p.Pix[off+2] = in.Cr[ci]
-				off += 3
-			}
-		}
 	default:
-		// Default to 4:4:4 subsampling.
-		for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
-			yy := (y - in.Rect.Min.Y) * in.YStride
-			cy := (y - in.Rect.Min.Y) * in.CStride
-			for x := in.Rect.Min.X; x < in.Rect.Max.X; x++ {
-				xx := (x - in.Rect.Min.X)
-				yi := yy + xx
-				ci := cy + xx
-				p.Pix[off+0] = in.Y[yi]
-				p.Pix[off+1] = in.Cb[ci]
-				p.Pix[off+2] = in.Cr[ci]
-				off += 3
+		// String is used to avoid Go build errors on older
+		// versions of Go.
+		if in.SubsampleRatio.String() == "YCbCrSubsampleRatio410" {
+			for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
+				yy := (y - in.Rect.Min.Y) * in.YStride
+				cy := (y/2 - in.Rect.Min.Y/2) * in.CStride
+				for x := in.Rect.Min.X; x < in.Rect.Max.X; x++ {
+					xx := (x - in.Rect.Min.X)
+					yi := yy + xx
+					ci := cy + xx/4
+					p.Pix[off+0] = in.Y[yi]
+					p.Pix[off+1] = in.Cb[ci]
+					p.Pix[off+2] = in.Cr[ci]
+					off += 3
+				}
+			}
+		} else {
+			// Default to 4:4:4 subsampling.
+			for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
+				yy := (y - in.Rect.Min.Y) * in.YStride
+				cy := (y - in.Rect.Min.Y) * in.CStride
+				for x := in.Rect.Min.X; x < in.Rect.Max.X; x++ {
+					xx := (x - in.Rect.Min.X)
+					yi := yy + xx
+					ci := cy + xx
+					p.Pix[off+0] = in.Y[yi]
+					p.Pix[off+1] = in.Cb[ci]
+					p.Pix[off+2] = in.Cr[ci]
+					off += 3
+				}
 			}
 		}
 	}

--- a/ycc.go
+++ b/ycc.go
@@ -137,6 +137,20 @@ func (p *ycc) YCbCr() *image.YCbCr {
 				off += 3
 			}
 		}
+	case image.YCbCrSubsampleRatio410:
+		for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
+			yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
+			cy := (y/2 - ycbcr.Rect.Min.Y/2) * ycbcr.CStride
+			for x := ycbcr.Rect.Min.X; x < ycbcr.Rect.Max.X; x++ {
+				xx := (x - ycbcr.Rect.Min.X)
+				yi := yy + xx
+				ci := cy + xx/4
+				ycbcr.Y[yi] = p.Pix[off+0]
+				ycbcr.Cb[ci] = p.Pix[off+1]
+				ycbcr.Cr[ci] = p.Pix[off+2]
+				off += 3
+			}
+		}
 	default:
 		// Default to 4:4:4 subsampling.
 		for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
@@ -201,6 +215,20 @@ func imageYCbCrToYCC(in *image.YCbCr) *ycc {
 				xx := (x - in.Rect.Min.X)
 				yi := yy + xx
 				ci := cy + xx
+				p.Pix[off+0] = in.Y[yi]
+				p.Pix[off+1] = in.Cb[ci]
+				p.Pix[off+2] = in.Cr[ci]
+				off += 3
+			}
+		}
+	case image.YCbCrSubsampleRatio410:
+		for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
+			yy := (y - in.Rect.Min.Y) * in.YStride
+			cy := (y/2 - in.Rect.Min.Y/2) * in.CStride
+			for x := in.Rect.Min.X; x < in.Rect.Max.X; x++ {
+				xx := (x - in.Rect.Min.X)
+				yi := yy + xx
+				ci := cy + xx/4
 				p.Pix[off+0] = in.Y[yi]
 				p.Pix[off+1] = in.Cb[ci]
 				p.Pix[off+2] = in.Cr[ci]

--- a/ycc.go
+++ b/ycc.go
@@ -154,6 +154,20 @@ func (p *ycc) YCbCr() *image.YCbCr {
 					off += 3
 				}
 			}
+		} else if ycbcr.SubsampleRatio.String() == "YCbCrSubsampleRatio411" {
+			for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
+				yy := (y - ycbcr.Rect.Min.Y) * ycbcr.YStride
+				cy := (y - ycbcr.Rect.Min.Y) * ycbcr.CStride
+				for x := ycbcr.Rect.Min.X; x < ycbcr.Rect.Max.X; x++ {
+					xx := (x - ycbcr.Rect.Min.X)
+					yi := yy + xx
+					ci := cy + xx/4
+					ycbcr.Y[yi] = p.Pix[off+0]
+					ycbcr.Cb[ci] = p.Pix[off+1]
+					ycbcr.Cr[ci] = p.Pix[off+2]
+					off += 3
+				}
+			}
 		} else {
 			// Default to 4:4:4 subsampling.
 			for y := ycbcr.Rect.Min.Y; y < ycbcr.Rect.Max.Y; y++ {
@@ -232,6 +246,20 @@ func imageYCbCrToYCC(in *image.YCbCr) *ycc {
 			for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
 				yy := (y - in.Rect.Min.Y) * in.YStride
 				cy := (y/2 - in.Rect.Min.Y/2) * in.CStride
+				for x := in.Rect.Min.X; x < in.Rect.Max.X; x++ {
+					xx := (x - in.Rect.Min.X)
+					yi := yy + xx
+					ci := cy + xx/4
+					p.Pix[off+0] = in.Y[yi]
+					p.Pix[off+1] = in.Cb[ci]
+					p.Pix[off+2] = in.Cr[ci]
+					off += 3
+				}
+			}
+		} else if in.SubsampleRatio.String() == "YCbCrSubsampleRatio411" {
+			for y := in.Rect.Min.Y; y < in.Rect.Max.Y; y++ {
+				yy := (y - in.Rect.Min.Y) * in.YStride
+				cy := (y - in.Rect.Min.Y) * in.CStride
 				for x := in.Rect.Min.X; x < in.Rect.Max.X; x++ {
 					xx := (x - in.Rect.Min.X)
 					yi := yy + xx

--- a/ycc_test.go
+++ b/ycc_test.go
@@ -33,7 +33,9 @@ func TestImage(t *testing.T) {
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio422),
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio440),
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio444),
-		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio410),
+	}
+	if rat410, ok := subsampleRatio410(); ok {
+		testImage = append(testImage, newYCC(image.Rect(0, 0, 10, 10), rat410))
 	}
 	for _, m := range testImage {
 		if !image.Rect(0, 0, 10, 10).Eq(m.Bounds()) {
@@ -61,7 +63,9 @@ func TestConvertYCbCr(t *testing.T) {
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio422),
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio440),
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio444),
-		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio410),
+	}
+	if rat410, ok := subsampleRatio410(); ok {
+		testImage = append(testImage, image.NewYCbCr(image.Rect(0, 0, 50, 50), rat410))
 	}
 
 	for _, img := range testImage {
@@ -151,7 +155,9 @@ func TestYCbCr(t *testing.T) {
 		image.YCbCrSubsampleRatio422,
 		image.YCbCrSubsampleRatio420,
 		image.YCbCrSubsampleRatio440,
-		image.YCbCrSubsampleRatio410,
+	}
+	if rat410, ok := subsampleRatio410(); ok {
+		subsampleRatios = append(subsampleRatios, rat410)
 	}
 	deltas := []image.Point{
 		image.Pt(0, 0),
@@ -214,4 +220,18 @@ func testYCbCr(t *testing.T, r image.Rectangle, subsampleRatio image.YCbCrSubsam
 			}
 		}
 	}
+}
+
+// subsampleRatio410 gets image.YCbCrSubsampleRatio410 on
+// newer versions of Go, but still compiles on old versions
+// of Go to maintain backwards compatibility.
+func subsampleRatio410() (image.YCbCrSubsampleRatio, bool) {
+	var i image.YCbCrSubsampleRatio
+	for i.String() != "YCbCrSubsampleRatioUnknown" {
+		if i.String() == "YCbCrSubsampleRatio410" {
+			return i, true
+		}
+		i++
+	}
+	return i, false
 }

--- a/ycc_test.go
+++ b/ycc_test.go
@@ -33,6 +33,7 @@ func TestImage(t *testing.T) {
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio422),
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio440),
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio444),
+		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio410),
 	}
 	for _, m := range testImage {
 		if !image.Rect(0, 0, 10, 10).Eq(m.Bounds()) {
@@ -60,6 +61,7 @@ func TestConvertYCbCr(t *testing.T) {
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio422),
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio440),
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio444),
+		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio410),
 	}
 
 	for _, img := range testImage {
@@ -149,6 +151,7 @@ func TestYCbCr(t *testing.T) {
 		image.YCbCrSubsampleRatio422,
 		image.YCbCrSubsampleRatio420,
 		image.YCbCrSubsampleRatio440,
+		image.YCbCrSubsampleRatio410,
 	}
 	deltas := []image.Point{
 		image.Pt(0, 0),

--- a/ycc_test.go
+++ b/ycc_test.go
@@ -34,8 +34,9 @@ func TestImage(t *testing.T) {
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio440),
 		newYCC(image.Rect(0, 0, 10, 10), image.YCbCrSubsampleRatio444),
 	}
-	if rat410, ok := subsampleRatio410(); ok {
-		testImage = append(testImage, newYCC(image.Rect(0, 0, 10, 10), rat410))
+	if rats, ok := subsampleRatio410And411(); ok {
+		testImage = append(testImage, newYCC(image.Rect(0, 0, 10, 10), rats[0]))
+		testImage = append(testImage, newYCC(image.Rect(0, 0, 10, 10), rats[1]))
 	}
 	for _, m := range testImage {
 		if !image.Rect(0, 0, 10, 10).Eq(m.Bounds()) {
@@ -64,8 +65,9 @@ func TestConvertYCbCr(t *testing.T) {
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio440),
 		image.NewYCbCr(image.Rect(0, 0, 50, 50), image.YCbCrSubsampleRatio444),
 	}
-	if rat410, ok := subsampleRatio410(); ok {
-		testImage = append(testImage, image.NewYCbCr(image.Rect(0, 0, 50, 50), rat410))
+	if rats, ok := subsampleRatio410And411(); ok {
+		testImage = append(testImage, image.NewYCbCr(image.Rect(0, 0, 50, 50), rats[0]))
+		testImage = append(testImage, image.NewYCbCr(image.Rect(0, 0, 50, 50), rats[1]))
 	}
 
 	for _, img := range testImage {
@@ -156,8 +158,8 @@ func TestYCbCr(t *testing.T) {
 		image.YCbCrSubsampleRatio420,
 		image.YCbCrSubsampleRatio440,
 	}
-	if rat410, ok := subsampleRatio410(); ok {
-		subsampleRatios = append(subsampleRatios, rat410)
+	if rats, ok := subsampleRatio410And411(); ok {
+		subsampleRatios = append(subsampleRatios, rats[0], rats[1])
 	}
 	deltas := []image.Point{
 		image.Pt(0, 0),
@@ -222,16 +224,24 @@ func testYCbCr(t *testing.T, r image.Rectangle, subsampleRatio image.YCbCrSubsam
 	}
 }
 
-// subsampleRatio410 gets image.YCbCrSubsampleRatio410 on
-// newer versions of Go, but still compiles on old versions
-// of Go to maintain backwards compatibility.
-func subsampleRatio410() (image.YCbCrSubsampleRatio, bool) {
+// subsampleRatio410And411 gets image.YCbCrSubsampleRatio410
+// and image.YCbCrSubsampleRatio411 on newer versions of Go,
+// but still compiles on old versions of Go to maintain
+// backwards compatibility.
+func subsampleRatio410And411() (ratios [2]image.YCbCrSubsampleRatio, ok bool) {
 	var i image.YCbCrSubsampleRatio
+	var numFound int
 	for i.String() != "YCbCrSubsampleRatioUnknown" {
-		if i.String() == "YCbCrSubsampleRatio410" {
-			return i, true
+		switch i.String() {
+		case "YCbCrSubsampleRatio410":
+			ratios[0] = i
+			numFound++
+		case "YCbCrSubsampleRatio411":
+			ratios[1] = i
+			numFound++
 		}
 		i++
 	}
-	return i, false
+	ok = (numFound == 2)
+	return
 }


### PR DESCRIPTION
See also #37 and #39.

This fixes a panic() for a few JPEG images found in the wild. Without this fix, a program which downloads and resizes tons of images from a source like [ImageNet](http://image-net.org) will eventually panic unexpectedly upon finding a 4:1:0 or 4:1:1 image.

To test this change, I have attached a 4:1:0 image found in the wild (from ImageNet, in fact). I zipped the image to prevent any potential image compression from Github (which would presumably destroy the 4:1:0-ness of the image).

[YCbCr_410.jpg.zip](https://github.com/nfnt/resize/files/458064/YCbCr_410.jpg.zip)

I could not find a 4:1:1 in the wild (although I only searched for several minutes). To address this, I have attached a small Go program which can convert an image in-memory to a 4:1:1 image, then resize said image. I could not use this program to generate a 4:1:1 image file because Go's jpeg package converts 4:1:1 into 4:2:0 (as of Go 1.7)

[411_test.go.zip](https://github.com/nfnt/resize/files/460582/411_test.go.zip)
