### PR TITLE
Don't resize inputs with zero width or height

### DIFF
--- a/resize.go
+++ b/resize.go
@@ -78,6 +78,7 @@ var blur = 1.0
 // If one of the parameters width or height is set to 0, its size will be calculated so that
 // the aspect ratio is that of the originating image.
 // The resizing algorithm uses channels for parallel computation.
+// If the input image has width or height of 0, it is returned unchanged.
 func Resize(width, height uint, img image.Image, interp InterpolationFunction) image.Image {
 	scaleX, scaleY := calcFactors(width, height, float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
 	if width == 0 {
@@ -89,6 +90,11 @@ func Resize(width, height uint, img image.Image, interp InterpolationFunction) i
 
 	// Trivial case: return input image
 	if int(width) == img.Bounds().Dx() && int(height) == img.Bounds().Dy() {
+		return img
+	}
+
+	// Input image has no pixels
+	if img.Bounds().Dx() <= 0 || img.Bounds().Dy() <= 0 {
 		return img
 	}
 

--- a/resize_test.go
+++ b/resize_test.go
@@ -37,6 +37,20 @@ func Test_ZeroImg(t *testing.T) {
 	}
 }
 
+func Test_HalfZeroImg(t *testing.T) {
+	zeroImg := image.NewGray16(image.Rect(0, 0, 0, 100))
+
+	m := Resize(0, 1, zeroImg, NearestNeighbor)
+	if m.Bounds() != zeroImg.Bounds() {
+		t.Fail()
+	}
+
+	m = Resize(1, 0, zeroImg, NearestNeighbor)
+	if m.Bounds() != zeroImg.Bounds() {
+		t.Fail()
+	}
+}
+
 func Test_CorrectResize(t *testing.T) {
 	zeroImg := image.NewGray16(image.Rect(0, 0, 256, 256))
 


### PR DESCRIPTION
Inputs having zero as both width and height were caught, but either one
alone caused a panic. This adds a test showing the old failing behavior
and adds a check for non-positive width/height. Since Resize doesn't
have an error return value, the behavior in this case is to return the
original image.

Fixes #52

This is the panic, which is uncatchable by client code since it happens in a new goroutine:

```
=== RUN   Test_HalfZeroImg
--- FAIL: Test_HalfZeroImg (0.00s)
panic: runtime error: makeslice: len out of range [recovered]
	panic: runtime error: makeslice: len out of range

goroutine 19 [running]:
panic(0x5122e0, 0xc420088150)
	/home/adam/go/gos/go1.7.3/src/runtime/panic.go:500 +0x1a1
testing.tRunner.func1(0xc42008e240)
	/home/adam/go/gos/go1.7.3/src/testing/testing.go:579 +0x25d
panic(0x5122e0, 0xc420088150)
	/home/adam/go/gos/go1.7.3/src/runtime/panic.go:458 +0x243
github.com/nfnt/resize.createWeightsNearest(0x8000000000000000, 0x2, 0x3ff0000000000000, 0x0, 0x0, 0x0, 0xc42000e760, 0xc420012680, 0xc4200127c0, 0x3f9eb851eb851eb8, ...)
	/home/adam/go/src/github.com/nfnt/resize/filters.go:127 +0x114
github.com/nfnt/resize.resizeNearest(0x8000000000000000, 0x1, 0x0, 0x0, 0x5b8280, 0xc420084180, 0x0, 0xffffffffffffffee, 0x5b6780)
	/home/adam/go/src/github.com/nfnt/resize/resize.go:535 +0x26a5
github.com/nfnt/resize.Resize(0x0, 0x1, 0x5b8280, 0xc420084180, 0x0, 0x0, 0x100000000)
	/home/adam/go/src/github.com/nfnt/resize/resize.go:101 +0x4963
github.com/nfnt/resize.Test_HalfZeroImg(0xc42008e240)
	/home/adam/go/src/github.com/nfnt/resize/resize_test.go:43 +0x112
testing.tRunner(0xc42008e240, 0x542f58)
	/home/adam/go/gos/go1.7.3/src/testing/testing.go:610 +0x81
created by testing.(*T).Run
	/home/adam/go/gos/go1.7.3/src/testing/testing.go:646 +0x2ec
exit status 2
FAIL	github.com/nfnt/resize	0.008s
```

This happens because the indexing arithmetic in resizeGray and friends attempts to access index 0 of a slice with no pixel data.