### PR TITLE
Use sub sample ratio from the input image

### DIFF
--- a/resize.go
+++ b/resize.go
@@ -167,7 +167,7 @@ func Resize(width, height uint, img image.Image, interp InterpolationFunction) i
 		// accessing the YCbCr arrays in a tight loop is slow.
 		// converting the image to ycc increases performance by 2x.
 		temp := newYCC(image.Rect(0, 0, input.Bounds().Dy(), int(width)), input.SubsampleRatio)
-		result := newYCC(image.Rect(0, 0, int(width), int(height)), image.YCbCrSubsampleRatio444)
+		result := newYCC(image.Rect(0, 0, int(width), int(height)), input.SubsampleRatio)
 
 		coeffs, offset, filterLength := createWeights8(temp.Bounds().Dy(), taps, blur, scaleX, kernel)
 		in := imageYCbCrToYCC(input)


### PR DESCRIPTION
Use sub sample ratio from the input image instead of hardcoding it.