### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/nfnt/resize
+
+go 1.18


### PR DESCRIPTION
Without `go.mod`, `go build` and `go test` fails with error:

```
go: cannot find main module, but found .git/config in /work/nfnt-resize
        to create a module there, run:
        go mod init
```

Since 1.16, golang will build packages in module-aware mode by default, see: https://go.dev/blog/go116-module-changes#modules-on-by-default
